### PR TITLE
Upgrade System.Security.Permission library to v7.

### DIFF
--- a/CredentialManagement/CredentialManagement.csproj
+++ b/CredentialManagement/CredentialManagement.csproj
@@ -13,11 +13,11 @@
         <Copyright>Copyright © Red Gate Software Ltd 2019</Copyright>
         <PackageProjectUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</PackageProjectUrl>
         <RepositoryUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</RepositoryUrl>
-        <PackageVersion>1.0.5</PackageVersion>
+        <PackageVersion>1.0.7</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Security.Permissions" Version="5.0.0"/>
+        <PackageReference Include="System.Security.Permissions" Version="7.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Use of  `Microsoft.Data.SqlClient` v. 5.1.1 library in many related solution, like SCA, require higher version of the `System.Security.Permission` which is referenced to this project. 

I upgraded version number to 1.0.7 (skipping 1.0.6) because I raised the version number of the `System.Security.Permission` to 7.
Previously `RedGate.ThirdParty.CredentialManagement.Standard` was in v1.0.5 and `System.Security.Permission` was no 5 respectively.
