### PR TITLE
System.Security.Permissions v6

### DIFF
--- a/CredentialManagement/CredentialManagement.csproj
+++ b/CredentialManagement/CredentialManagement.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Security.Permissions" Version="7.0.0" />
+        <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
All of our other dependencies are on `System.Security.Permissions` v6.0.0 instead of v7 so we need this branch so we can reference v6 so it doesn't break our other dependencies.

DO NOT MERGE