### PR TITLE
Update Security.Permissions to version 9.0.0

### DIFF
--- a/CredentialManagement/CredentialManagement.csproj
+++ b/CredentialManagement/CredentialManagement.csproj
@@ -13,11 +13,11 @@
         <Copyright>Copyright © Red Gate Software Ltd 2019</Copyright>
         <PackageProjectUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</PackageProjectUrl>
         <RepositoryUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</RepositoryUrl>
-        <PackageVersion>1.0.9</PackageVersion>
+        <PackageVersion>1.0.10</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Security.Permissions" Version="9.0.3" />
+        <PackageReference Include="System.Security.Permissions" Version="9.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Security.Permissions to version 9.0.0 to resolve SCA DeploymentWithReports Test 

```
Error|RedGate.Versioning.Client.MsBuild.ErrorHandling.BuildExceptionHandler|23| The type initializer for 'CredentialManagement.Credential' threw an exception.
System.TypeInitializationException: The type initializer for 'CredentialManagement.Credential' threw an exception. ---> System.IO.FileLoadException: Could not load file or assembly 'System.Security.Permissions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
   at CredentialManagement.Credential..cctor()
   --- End of inner exception stack trace ---
```