### PR TITLE
Sign and publish package

### DIFF
--- a/.github/actions/push-package/action.yml
+++ b/.github/actions/push-package/action.yml
@@ -1,0 +1,32 @@
+name: "Push package"
+
+description: "Push package to NuGet"
+
+inputs:
+  path:
+    description: "Path to the package that will be pushed"
+    required: true
+  package:
+    description: "Name of the package that will be pushed"
+    required: true
+
+runs:
+  using: "composite"
+  
+  steps:
+    - name: Get Vault Secrets
+      uses: hashicorp/vault-action@v3.4.0
+      with:
+        method: jwt
+        url: https://vault.red-gate.com
+        path: gha_jwt
+        role: "gha-CredentialManagement"
+        secrets: |
+              build-secrets/data/shared/nuget username | NUGET_USER;
+              build-secrets/data/shared/nuget password | NUGET_TOKEN;
+              build-secrets/data/shared/nuget url | NUGET_RG_FEED;
+
+    - name: Push package
+      shell: pwsh
+      run: |
+          ./.github/actions/push-package/push-package.ps1 ${{ inputs.path }} ${{ inputs.package }}

--- a/.github/actions/push-package/push-package.ps1
+++ b/.github/actions/push-package/push-package.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop"
+$filepath=$args[0]
+$filename=$args[1]
+
+$package = (Get-ChildItem -Path $filepath -Filter $filename*.nupkg -Recurse).FullName
+
+dotnet nuget add source "$env:NUGET_RG_FEED" `
+    --name red-gate-vsts-main-v3 `
+    --username "$env:NUGET_USER" `
+    --password "$env:NUGET_TOKEN" `
+    --store-password-in-clear-text
+
+dotnet nuget push "$package" --api-key "$env:NUGET_TOKEN" --source "$env:NUGET_RG_FEED" --skip-duplicate

--- a/.github/actions/sign-artifacts/action.yml
+++ b/.github/actions/sign-artifacts/action.yml
@@ -14,7 +14,8 @@ runs:
     - name: Install sign tool
       shell: bash
       run: |
-        dotnet tool install sign --tool-path "./.signing" --version 0.9.1-beta.25278.1
+        mkdir '.signing'
+        dotnet tool install --tool-path "./.signing" --prerelease sign
 
     - name: Get Vault Secrets
       uses: hashicorp/vault-action@v3.4.0
@@ -50,6 +51,8 @@ runs:
             -kvu "$env:VAULT_URL" `
             -kvc "$env:VAULT_CERTIFICATE" `
             -kvm $true `
+            
+          if ($LASTEXITCODE -ne 0) { throw "Failed to sign files" }
         }
 
     - name: Validate signature

--- a/.github/actions/sign-artifacts/action.yml
+++ b/.github/actions/sign-artifacts/action.yml
@@ -1,0 +1,65 @@
+name: "Sign artifacts"
+
+description: "Sign artifacts using dotnet sign tool"
+
+inputs:
+  artifacts:
+    description: "Path to the artifact to be signed"
+    required: true
+
+runs:
+  using: "composite"
+  
+  steps:
+    - name: Install sign tool
+      shell: bash
+      run: |
+        dotnet tool install sign --tool-path "./.signing" --version 0.9.1-beta.25278.1
+
+    - name: Get Vault Secrets
+      uses: hashicorp/vault-action@v3.4.0
+      with:
+        method: jwt
+        url: https://vault.red-gate.com
+        path: gha_jwt
+        role: "gha-CredentialManagement"
+        secrets: |
+          build-secrets/data/shared/dotnet_sign_sp user | USER;
+          build-secrets/data/shared/dotnet_sign_sp user_password | PASSWORD;
+          build-secrets/data/shared/dotnet_sign_sp tenant_id | TENANT;
+          build-secrets/data/shared/dotnet_sign_sp key_vault_url | VAULT_URL;
+          build-secrets/data/shared/dotnet_sign_sp key_vault_certificate_name | VAULT_CERTIFICATE;
+
+    - name: Azure login
+      shell: bash
+      run: az login --allow-no-subscriptions --service-principal -u "$USER" -p "$PASSWORD" --tenant "$TENANT"
+
+    - name: Sign artifact
+      shell: pwsh
+      run: |
+        $artifacts = "${{ inputs.artifacts }}" -split ","
+
+        foreach ($artifact in $artifacts)
+        {
+          $trimmedArtifact = $artifact.Trim()
+
+          ./.signing/sign code azure-key-vault `
+            $trimmedArtifact `
+            --description "Red Gate Software Ltd." `
+            -u "https://www.red-gate.com" `
+            -kvu "$env:VAULT_URL" `
+            -kvc "$env:VAULT_CERTIFICATE" `
+            -kvm $true `
+        }
+
+    - name: Validate signature
+      shell: pwsh
+      run: |
+        $artifacts = "${{ inputs.artifacts }}" -split ","
+
+        foreach ($artifact in $artifacts)
+        {       
+          $trimmedArtifact = $artifact.Trim()
+     
+          ./.github/actions/sign-artifacts/validate-signature.ps1 $trimmedArtifact
+        }

--- a/.github/actions/sign-artifacts/validate-signature.ps1
+++ b/.github/actions/sign-artifacts/validate-signature.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+$filepath=$args[0]
+
+If ((Get-AuthenticodeSignature $filepath).Status -eq 'Valid')
+{
+    Write-Host "Authenticode valid for $filepath"
+} Else {
+    Throw "Authenticode invalid for $filepath"
+}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -29,4 +29,9 @@ jobs:
 
       - name: Create the package
         run: dotnet pack --configuration Release
-        # Publish the package to NuGet
+
+      - name: Publish to NuGet
+        uses: ./.github/actions/push-package
+        with:
+          path: ./CredentialManagement/bin/Release
+          package: RedGate.ThirdParty.CredentialManagement.Standard

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,6 +1,10 @@
 name: CI Pipeline
 on: [push, workflow_dispatch]
 
+permissions:
+  id-token: write # required for hashicorp/vault-action to work
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-slim

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Build project
         run: dotnet build --configuration Release
 
-      - uses: ./.github/actions/sign-artifacts
+      - name: Sign artifacts
+        uses: ./.github/actions/sign-artifacts
         with:
           artifacts: |
             ./CredentialManagement/bin/Release/netstandard2.0/RedGate.ThirdParty.CredentialManagement.Standard.dll

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,12 +7,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
 
       - name: Build project
         run: dotnet build --configuration Release
-        # Sign dll
+
+      - uses: ./.github/actions/sign-artifacts
+        with:
+          artifacts: |
+            ./CredentialManagement/bin/Release/netstandard2.0/RedGate.ThirdParty.CredentialManagement.Standard.dll
+
       - name: Create the package
         run: dotnet pack --configuration Release
         # Publish the package to NuGet

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-slim
+    runs-on: windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline
 on: 
   push:
-    branches: [ main ]
+    branches: [ master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,5 +1,8 @@
 name: CI Pipeline
-on: [push, workflow_dispatch]
+on: 
+  push:
+    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   id-token: write # required for hashicorp/vault-action to work

--- a/README.md
+++ b/README.md
@@ -19,6 +19,5 @@ We have removed classes and methods we do not use, and assimilated these classes
 * secondly, the Credential Management Windows API is very stable, so we're unlikely to need constant bleeding-edge updates.
 
 # Publishing a package
-Build using your favorite IDE
-From the repo root,
-"<path to nuget exe: .\.build\nuget.exe>" push "<path to nupkg: .\CredentialManagement\bin\Debug\RedGate.ThirdParty.CredentialManagement.Standard.1.0.X.nupkg >" -apikey <VSTS_API_key> -source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json
+
+This project automatically builds, signs, packages and pushes to the RedGate NuGet reprository on pushes to the default branch using the ci-pipeline GitHub workflow.


### PR DESCRIPTION
I've tested a few bits and bobs locally and before making it only run on default.
- Tested signing + validation on GHA, see previous workflow runs
- Tested getting the path to the nupkg locally but not pushing to NuGet

Made it so it only runs on default branch due to versioning not having pre-release and I'm not sure it's worth the effort in this repo.

There is an error logged during signing but the signing does succeed, see issue in dotnet sign repo.
https://github.com/dotnet/sign/issues/950

Part of #7 