### PR TITLE
switch to azure-cli login

### DIFF
--- a/.github/actions/sign-artifacts/action.yml
+++ b/.github/actions/sign-artifacts/action.yml
@@ -48,9 +48,9 @@ runs:
             $trimmedArtifact `
             --description "Red Gate Software Ltd." `
             -u "https://www.red-gate.com" `
+            -act "azure-cli" `
             -kvu "$env:VAULT_URL" `
             -kvc "$env:VAULT_CERTIFICATE" `
-            -kvm $true `
             
           if ($LASTEXITCODE -ne 0) { throw "Failed to sign files" }
         }


### PR DESCRIPTION
-kvm flag is deprecated in favour of using -act and specifying the authentication type or not specifying -act and relying on [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) to choose the authentication strategy (basically goes over the list and tries them one by one until one succeeds).

I'll make the same change across our repos where -kvm is specified

part of #7 