### PR TITLE
Run the workflow on branches except for the publish step

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    name: Build, Sign and Publish
     runs-on: windows-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,8 +1,5 @@
 name: CI Pipeline
-on: 
-  push:
-    branches: [ master ]
-  workflow_dispatch:
+on: [push, workflow_dispatch]
 
 permissions:
   id-token: write # required for hashicorp/vault-action to work
@@ -31,6 +28,7 @@ jobs:
         run: dotnet pack --configuration Release
 
       - name: Publish to NuGet
+        if: github.ref == 'refs/heads/master'
         uses: ./.github/actions/push-package
         with:
           path: ./CredentialManagement/bin/Release

--- a/CredentialManagement/CredentialManagement.csproj
+++ b/CredentialManagement/CredentialManagement.csproj
@@ -13,7 +13,7 @@
         <Copyright>Copyright © Red Gate Software Ltd 2019</Copyright>
         <PackageProjectUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</PackageProjectUrl>
         <RepositoryUrl>https://github.com/red-gate/Redgate.ThirdParty.CredentialManagement.Standard</RepositoryUrl>
-        <PackageVersion>1.0.10.1</PackageVersion>
+        <PackageVersion>1.0.10.2</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Also added a name to be more descriptive.
And increased the version number so we deploy the signed dll.

part of #7 