### PR TITLE
Update workflow reference from `master` to `main`

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet pack --configuration Release
 
       - name: Publish to NuGet
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: ./.github/actions/push-package
         with:
           path: ./CredentialManagement/bin/Release


### PR DESCRIPTION
Fixes the filtering for branches from the old `master` default to the new `main` default
Completes #13 